### PR TITLE
#165788473 Add index and 404 pages for use by github pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <meta name="Author" content="Orji Chidi Matthew">
+        <meta name="description" content="Easily accessible short term loans">
+        <meta name="keywords", content="loan, cash, short term loan">
+        <link rel="stylesheet" href="https://chidimo.github.io/QuickCredit/UI/css/style.css">
+        <title>Quick Credit | Error 404</title>
+    </head>
+
+    <body>
+        <section id="showcase">
+            <div class="container">
+                <h1 style="color:#547CFF">Quick Credit</h1>
+                <h2>Error 404 | Sorry wayfarer. It seems what you're looking for has redeployed to Kuvuki land.</h2>
+                <a style="text-decoration:none" href="https://chidimo.github.io/QuickCredit/index.html"><h1>Return To Full Site</h1></a>
+            </div>
+        </section>
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <meta name="Author" content="Orji Chidi Matthew">
+        <meta name="description" content="Easily accessible short term loans">
+        <meta name="keywords", content="loan, cash, short term loan">
+        <link rel="stylesheet" href="UI/css/style.css">
+        <title>Quick Credit | Splash</title>
+    </head>
+
+    <body>
+
+        <section id="showcase">
+            <div class="container">
+                <h1 style="color:#547CFF">Quick Credit</h1>
+                <a style="text-decoration:none" href="UI/index.html"><h1>View Full Site</h1></a>
+
+                <h3>The following pages can only be accessed by manually typing the URL in the address bar.</h3>
+                <h3>These pages require that the user be logged in.</h3>
+                <ul>
+                    <li>Dashboard: <a href="UI/dashboard.html">dashboard.html</a></li>
+                    <li>Admin Dashboard: <a href="UI/admin.html">admin.html</a></li>
+                    <li>Users: <a href="UI/users.html">users.html</a></li>
+                    <li>User: <a href="UI/user.html">user.html</a></li>
+                    <li>Loans: <a href="UI/loans.html">loans.html</a></li>
+                    <li>loan: <a href="UI/loan.html">loan.html</a></li>
+                </ul>
+            </div>
+
+        </section>
+        
+    </body>
+</html>


### PR DESCRIPTION
#### What does this PR do?

Add index and 404 pages for use by github pages

#### Description of Task to be completed?

Add index and 404 pages for use by Github pages

#### How should this be manually tested?

Navigate to the hosted version of the UI templates on GitHub pages by following this [link](https://chidimo.github.io/QuickCredit/)

#### Any background context you want to provide?

Github pages by default displays the project's README file. But a provided index.html page overrides this default.
Github pages can either display its own 404 page or display a custom 404 page if provided.

#### What are the relevant pivotal tracker stories?

[165788473](https://www.pivotaltracker.com/story/show/165788473)

#### Screenshots (if appropriate)

Nil

#### Questions:

Nil
