### PR TITLE
#165865116 Fix failing coverage reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yarn-error.log
 coverage/
 .nyc_output/
 dist/
+.coveralls.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ matrix:
 cache:
     directories: "node_modules"
 
-# Generate and send coverage data to coveralls
-after_script: yarn test-coveralls
+# Generate and send coverage report to coveralls
+after_success: yarn coverage

--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
     "scripts": {
         "start": "node --require @babel/register ./bin/www ",
         "devstart": "nodemon --exec babel-node ./bin/www",
-        "build": "babel . --out-dir dist",
-        "test": "nyc mocha --require @babel/register --require should",
         "lint": "./node_modules/.bin/eslint ./",
-        "test-coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec test/*",
-        "test-coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
+        "test": "nyc --reporter=html --reporter=text mocha --require @babel/register --require should",
+        "cover": "nyc report --reporter=text-lcov | coveralls",
+        "coverage": "nyc report --reporter=text-lcov | coveralls && rm -rf ./.nyc_output && rm -rf coverage/"
     },
     "bugs": {
         "url": "https://github.com/chidimo/Quick-Credit/issues"
@@ -43,7 +42,6 @@
         "eslint": "^5.16.0",
         "istanbul": "^0.4.5",
         "mocha": "^6.1.4",
-        "mocha-lcov-reporter": "^1.3.0",
         "nodemon": "^1.18.11",
         "nyc": "^14.1.0",
         "should": "^13.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,11 +2977,6 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha-lcov-reporter@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz#469bdef4f8afc9a116056f079df6182d0afb0384"
-  integrity sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=
-
 mocha@^6.1.4:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.1.4.tgz#e35fada242d5434a7e163d555c705f6875951640"


### PR DESCRIPTION
#### What does this PR do?

Fix failing coverage report to coveralls

#### Description of Task to be completed?

Replace mocha-lcov-reporter with nyc
Add coveralls repo token to .coverage.yml, then ignore. This sends the
coverage report from my local machine.
Run coverage reporting after_success

#### How should this be manually tested?

1. Clone the repo
1. cd into the root folder on a `cmd` shell and issue command `yarn install`.
1. Execute command `yarn test`

#### Any background context you want to provide?

Nil

#### What are the relevant pivotal tracker stories?

[165865116](https://www.pivotaltracker.com/story/show/165865116)

#### Screenshots (if appropriate)

Nil

#### Questions:

Nil
