### PR TITLE
#166260262 Move newsletter subscription form to sidebar

### DIFF
--- a/UI/css/style.css
+++ b/UI/css/style.css
@@ -300,19 +300,26 @@ ul.base_ul {
 /* Showcase */
 
 #showcase {
-    min-height: 400px;
+    display: flex;
+    min-height: 700px;
     text-align: center;
-    background: url('../img/architecture-bridge-buildings-374685.jpg') no-repeat 0 -500px;
+    background: url('../img/architecture-bridge-buildings-374685.jpg') no-repeat 0 -400px;
 }
 
 #showcase h1 {
-    margin-top: 100px;
-    font-size: 50px;
-    margin-bottom: 10px;
+    font-size: 55px;
 }
 
 #showcase p {
     font-size: 18px;
+}
+
+/* newsletter */
+
+#newsletter {
+    position: fixed;
+    right: 0;
+    top: 300px;
 }
 
 #newsletter {
@@ -322,19 +329,21 @@ ul.base_ul {
 }
 
 #newsletter h1 {
-    float: left;
+    margin-top: 0;
 }
 
-#newsletter form {
-    float: right;
-    margin-top: 25px;
+.newsletter-container {
+    text-align: left;
+    margin: auto;
+    padding: 25px 10px;
 }
 
 #newsletter input[type='email'] {
-    width: 250px;
+    width: 100%;
 }
 
 #newsletter button.subscribe_button {
+    width: 100%;
     height: 44px;
 }
 
@@ -399,6 +408,15 @@ footer {
         margin-left: auto;
         margin-right: auto;
     }
+
+    /* newsletter */
+    section#newsletter {
+        position: inherit;
+    }
+
+    #newsletter input[type='email'] {
+        margin-bottom: 5px;
+    }
 }
 
 @media (max-width: 768px) {
@@ -421,22 +439,9 @@ footer {
         width: 95%;
     }
 
-    header #branding,
-    #newsletter h1,
-    #newsletter form
-    {
+    header #branding {
         float: none;
         text-align: center;
-        width: 100%;
-    }
-
-    #newsletter input[type='email'] {
-        width: 100%;
-        margin-bottom: 5px;
-    }
-
-    #newsletter button {
-        display: block;
         width: 100%;
     }
 
@@ -694,7 +699,6 @@ hr.section_divider {
     display: grid;
     grid-row-gap: 50px;
     margin-right: auto;
-    /* font-weight: bold; */
     grid-template-columns: 30% 1% 68%;
 }
 

--- a/UI/index.html
+++ b/UI/index.html
@@ -9,6 +9,7 @@
         <meta name="keywords", content="loan, cash, short term loan">
         <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css?family=Open+Sans|Roboto+Slab&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
         <link rel="stylesheet" href="./css/style.css">
         <title>Quick Credit | Welcome</title>
     </head>
@@ -36,26 +37,27 @@
                         <h1>Accessible and affordable funds for businesses</h1>
                     </div>
                 </section>
-                
-                <section id="newsletter">
+
+                <section class="info_section">
                     <div class="container">
+                        <h2>Why Choose Quick Credit</h2>
+                        <ul class="">
+                            <li><i class="fas fa-hand-point-right"></i> Accessible and affordable funds</li>
+                            <li><i class="fas fa-hand-point-right"></i> Flexible payment options</li>
+                            <li><i class="fas fa-hand-point-right"></i> Grow your business</li>
+                            <li><i class="fas fa-hand-point-right"></i> Enjoy peace of mind</li>
+                        </ul>
+                    </div>
+                </section>
+
+                <section id="newsletter">
+                    <div class="newsletter-container">
+                        <h1>Stay Informed</h1>
                         <h1>Subscribe To Our Newsletter</h1>
                         <form action="">
                             <input type="email" placeholder="Email">
                             <button class="button_1 subscribe_button bordered">Subscribe</button>
                         </form>
-                    </div>
-                </section>
-                
-                <section class="info_section">
-                    <div class="container">
-                        <h2>Benefits</h2>
-                        <ul class="">
-                            <li>Accessible funds</li>
-                            <li>Affordable and flexible payment options</li>
-                            <li>Grow your business</li>
-                            <li>Enjoy peace of mind</li>
-                        </ul>
                     </div>
                 </section>
             </div>

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -15,6 +15,13 @@ const AuthenticationMiddleware = {
             return next();
         }
         const token = req.headers['x-access-token'];
+        if (!token) {
+            const msg = 'Include a valid token in the x-access-token header';
+            return res.status(422).json({ 
+                error: 'No token provided',
+                msg 
+            });
+        }
         try {
             req.user = jwt.verify(token, Settings.jwtSecret);
             req.token = token;


### PR DESCRIPTION
#### What does this PR do?

Move the newsletter subscription form to the sidebar

#### Description of Task to be completed?

1. Display the form as a sidebar for larger screens and as an inline element for smaller screens.
1. Return appropriate error message if jwt token is not included in a request.

#### How should this be manually tested?

1. Clone the repo
1. Open `/UI/index.html` in a browser
1. Toggle the browser size to see the responsiveness of the subscription form.

#### Any background context you want to provide?

It was suggested during my presentation that the benefits of using the quick credit service should stand out first before the newsletter section. So I decided to move the form to the side. This lets me keep it in front without distracting from the benefits I wish to showcase.

#### What are the relevant pivotal tracker stories?

[166260262](https://www.pivotaltracker.com/story/show/166260262)

#### Screenshots (if appropriate)

![Quick Credit _ Welcome - Brave 5_27_2019 12_35_28 AM](https://user-images.githubusercontent.com/5418113/58388495-bde4c380-8017-11e9-864f-a4ffa4e7d685.png)
![Quick Credit _ Welcome - Brave 5_27_2019 12_35_48 AM](https://user-images.githubusercontent.com/5418113/58388496-bde4c380-8017-11e9-9358-093dca4bacca.png)

#### Questions:

Nil
