### PR TITLE
refactor(sign up): require only email and password

### DIFF
--- a/UI/authentication.html
+++ b/UI/authentication.html
@@ -63,12 +63,6 @@
                             <form class="authentication sign_up" action="">
                                 <label for="email"><b>Email</b></label>
                                 <input id="signup_email" type="email" placeholder="Enter email" name="email" required>
-            
-                                <label for="first_name"><b>First Name</b></label>
-                                <input id="first_name" type="text" placeholder="First Name" name="first_name" required>
-                
-                                <label for="last_name"><b>Last Name</b></label>
-                                <input id="last_name" type="text" placeholder="Last Name" name="last_name" required>
                 
                                 <label for="password"><b>Password</b></label>
                                 <input id="signup_password" type="password" placeholder="Enter password" name="password" required>

--- a/UI/js/authentication.js
+++ b/UI/js/authentication.js
@@ -71,7 +71,7 @@ signup_form.addEventListener('click', e => {
     const firstname = document.getElementById('first_name').value;
     const lastname = document.getElementById('last_name').value;
 
-    const body = { email, password, confirm_password, firstname, lastname };
+    const body = { email, password, confirm_password };
 
     const options = {
         method: 'POST',

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -21,13 +21,18 @@ const AuthController = {
                 .status(409)
                 .json({ error: `User with email ${email} already exists` });
         }
-        const { rows } = await add_user_to_db(users_model, req, res);
-        const [ { id }, ] = rows;
-        const clause = `WHERE id=${id}`;
-        const err_msg = `User with id ${id} not found`;
-        const user = await get_existing_user(users_model, res, clause, err_msg);
-        sendSignUpMessage(user, req);
-        return res.status(201).json({ data: { ...user, token: req.token } });
+        try {
+            const { rows } = await add_user_to_db(users_model, req, res);
+            const [ { id }, ] = rows;
+            const clause = `WHERE id=${id}`;
+            const err_msg = `User with id ${id} not found`;
+            const user = await get_existing_user(
+                users_model, res, clause, err_msg);
+            sendSignUpMessage(user, req);
+            return res.status(201)
+                .json({ data: { ...user, token: req.token } });
+        }
+        catch (e) { return; }
     },
 
     signin: async (req, res) => {

--- a/controllers/helpers/AuthController.js
+++ b/controllers/helpers/AuthController.js
@@ -57,13 +57,11 @@ export const check_password = async (model_instance, email, password, res) => {
 };
 
 export const add_user_to_db = async (model_instance, req, res) => {
-    const { email, password, firstname, lastname } = req.body;
+    const { email, password } = req.body;
 
     try {
         return await model_instance.insert_with_return(
-            '(email, firstname, lastname, password)',
-            `'${email}', '${firstname}', '${lastname}', 
-            '${hashPassword(password)}'`
+            '(email, password)', `'${email}', '${hashPassword(password)}'`
         );                    
     }
     catch (e) { return InternalServerError(res, e);}

--- a/middleware/validators.users.js
+++ b/middleware/validators.users.js
@@ -19,13 +19,6 @@ const validate_name = field => (
 );
 
 const UsersValidators = {
-    validateNames: [
-        validate_name('firstname'),
-        validate_name('lastname'),
-        sanitizeBody('firstname').trim().escape(),
-        sanitizeBody('lastname').trim().escape()
-    ],
-    
     emailValidator: [
         body('email')
             .isEmail()

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,7 +13,6 @@ const router = express.Router();
 router.post('/auth/signup',
     UsersValidators.emailValidator,
     UsersValidators.passwordValidator,
-    UsersValidators.validateNames,
     UsersValidators.confirmPasswordValidator,
     AuthenticationMiddleware.generateToken,
     AuthController.signup

--- a/test/users-spec.js
+++ b/test/users-spec.js
@@ -39,8 +39,7 @@ describe('/api/v1/users', () => {
             it('should register and return user', done => {
                 const data = {
                     email: 'valid@address.com', password: 'password',
-                    confirm_password: 'password', firstname: 'chidi',
-                    lastname: 'orjinta'
+                    confirm_password: 'password'
                 };
                 server
                     .post('/api/v1/auth/signup')
@@ -50,10 +49,6 @@ describe('/api/v1/users', () => {
                         res.status.should.equal(201);
                         res.body.data.should.have.property(
                             'email', `${data.email}`);
-                        res.body.data.should.have.property(
-                            'firstname', `${data.firstname}`);
-                        res.body.data.should.have.property(
-                            'lastname', `${data.lastname}`);
                         res.body.data.should.have.property('token');
                         done();
                     });
@@ -92,40 +87,6 @@ describe('/api/v1/users', () => {
                         res.status.should.equal(422);
                         res.body.errors[0].msg.should.equal(
                             'Password confirmation does not match password');
-                        done();
-                    });
-            });
-                
-            it('should catch no firstname error', done => {
-                const data = {
-                    email: 'valid@address.com', password: 'password',
-                    confirm_password: 'password', lastname: 'orjinta'
-                };
-                server
-                    .post('/api/v1/auth/signup')
-                    .send(data)
-                    .expect(200)
-                    .end((err, res) => {
-                        res.status.should.equal(422);
-                        res.body.errors[0].msg.should.equal(
-                            'Firstname is required');
-                        done();
-                    });
-            });
-                
-            it('should catch no lastname error', done => {
-                const data = {
-                    email: 'valid@address.com', password: 'password',
-                    confirm_password: 'password', firstname: 'chidi'
-                };
-                server
-                    .post('/api/v1/auth/signup')
-                    .send(data)
-                    .expect(200)
-                    .end((err, res) => {
-                        res.status.should.equal(422);
-                        res.body.errors[0].msg.should.equal(
-                            'Lastname is required');
                         done();
                     });
             });


### PR DESCRIPTION
#### What does this PR do?

Simplify sign up process by requiring only username and password

#### Description of Task to be completed?

1. Require only email and password in sign up form

#### How should this be manually tested?

##### Backend test

1. Clone the repo
1. `cd` into the root folder on a `cmd` shell and run `yarn install`. PowerShell is fine also.
1. Setup a PostgreSQL DB.
1. Define a `.env` file in the root of the project and supply values for the following parameters
    ```.env
    JWT_SECRET=<json-web-token-secret>
    DBNAME=<database-name>
    PGPASSWORD=<postgres-db-password>
    PGHOST=<postgres-db-host>
    PGUSER=<postgres-db-user>
    PGPORT=<postgres-db-port>
    ```
1. Create a PostgreSQL database called `testdb`.
1. Run command `yarn test`

##### Frontend test

1. Clone the repo
1. Open `/UI/authentication.html` in a browser
1. Click the signup tab

#### Any background context you want to provide?

Nil

#### What are the relevant pivotal tracker stories?

[166268488](#166268488)

#### Screenshots (if appropriate)

![Quick Credit _ Registration - Brave 5_27_2019 5_20_50 PM](https://user-images.githubusercontent.com/5418113/58431005-d39fca80-80a3-11e9-9c8e-51762777d828.png)

#### Questions: